### PR TITLE
Fix connection shutdown cleanup

### DIFF
--- a/networking/connection.py
+++ b/networking/connection.py
@@ -35,13 +35,13 @@ class ConnectionListener:
                 self.connections.append(con)
 
         logger.info('Connection listener is shutting down...')
-        for connection in self.connections:
+        with self.connection_list_lock:
+            active_connections = list(self.connections)
+        for connection in active_connections:
             connection: Connection = connection
             connection.interrupt()
-        for connection in self.connections:
+        for connection in active_connections:
             connection.join()
-            with self.connection_list_lock:
-                self.connections.remove(connection)
         
         self.server.close()
         logger.info('Terminating listener')


### PR DESCRIPTION
## Summary
- stop editing the connection list while iterating
- iterate over a copy of connections when shutting down

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856c42d84248320abe3e34733089e06