### PR TITLE
Fix typo in send_packet docstring

### DIFF
--- a/networking/connection.py
+++ b/networking/connection.py
@@ -100,7 +100,7 @@ class Connection:
     def send_packet(self, *clientbound_packets: packet.ClientboundPacket) -> packet.ServerboundPacket:
         '''
         Queue packets to be sent to the client.
-        Packets given in this function are guranteed to be sent in the order they are given as soon as next opportunity within network flow is available, and receives a response from the client.
+        Packets given in this function are guaranteed to be sent in the order they are given as soon as next opportunity within network flow is available, and receives a response from the client.
 
         Packets can be sent as a bundle as long as it won't break the protocol.
         Generally, bundle packets are only acceptable in play state, where packets are surrounded by bundle delimiters (id = 0x00).


### PR DESCRIPTION
## Summary
- fix spelling of `guaranteed` in Connection.send_packet docstring

## Testing
- `python -m compileall -q networking/connection.py`

------
https://chatgpt.com/codex/tasks/task_e_6856c7cf90d4832080b4bc386b741dcc