### PR TITLE
Fix default docstring for ByteBuffer

### DIFF
--- a/networking/data_type.py
+++ b/networking/data_type.py
@@ -6,7 +6,7 @@ class ByteBuffer:
     def __init__(self, byte_order='big'):
         """
         Parameters:
-        byte_order (str): The byte order of the buffer. Can be either 'little' or 'big'. Defaults to 'little.
+        byte_order (str): The byte order of the buffer. Can be either 'little' or 'big'. Defaults to 'big'.
         """
         self.buffer = bytearray()
         self.position = 0


### PR DESCRIPTION
## Summary
- correct the default value description in `ByteBuffer.__init__`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c7f1a7e88320adec7ae1d7496dc6