### PR TITLE
Add varint tests and fix implementation

### DIFF
--- a/networking/data_type.py
+++ b/networking/data_type.py
@@ -105,10 +105,13 @@ class BufferedPacket(ByteBuffer):
         shift = 0
         while True:
             b = self.read_uint8()
-            result |= (b & 127) << shift
-            shift += 7
-            if not b & 128:
+            result |= (b & 0x7F) << shift
+            if not b & 0x80:
                 break
+            shift += 7
+        # convert from unsigned to signed 32-bit value
+        if result & 0x80000000:
+            result -= 0x100000000
         return result
     
     def read_varlong(self):
@@ -116,10 +119,12 @@ class BufferedPacket(ByteBuffer):
         shift = 0
         while True:
             b = self.read_uint8()
-            result |= (b & 127) << shift
-            shift += 7
-            if not b & 128:
+            result |= (b & 0x7F) << shift
+            if not b & 0x80:
                 break
+            shift += 7
+        if result & 0x8000000000000000:
+            result -= 0x10000000000000000
         return result
 
     def read_utf8_string(self, n: int) -> str:
@@ -194,22 +199,28 @@ class BufferedPacket(ByteBuffer):
     def write_varint(self, value: int):
         if value < -2147483648 or value > 2147483647:
             raise ValueError('Int value out of range')
+        unsigned = value & 0xFFFFFFFF
         while True:
-            if (value & -128) == 0:
-                self.write_uint8(value)
-                return
-            self.write_uint8(value & 127 | 128)
-            value = value >> 7
+            temp = unsigned & 0x7F
+            unsigned >>= 7
+            if unsigned != 0:
+                temp |= 0x80
+            self.write_uint8(temp)
+            if unsigned == 0:
+                break
     
     def write_varlong(self, value: int):
         if value < -9223372036854775808 or value > 9223372036854775807:
             raise ValueError('Long value out of range')
+        unsigned = value & 0xFFFFFFFFFFFFFFFF
         while True:
-            if (value & -128) == 0:
-                self.write_uint8(value)
-                return
-            self.write_uint8(value & 127 | 128)
-            value = value >> 7
+            temp = unsigned & 0x7F
+            unsigned >>= 7
+            if unsigned != 0:
+                temp |= 0x80
+            self.write_uint8(temp)
+            if unsigned == 0:
+                break
 
     def write_utf8_string(self, string: str, n: int):
         if n > 32767:

--- a/tests/test_bytebuffer.py
+++ b/tests/test_bytebuffer.py
@@ -1,0 +1,13 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from networking.data_type import BufferedPacket
+
+@pytest.mark.parametrize('value', [0, 1, 127, 128, 255, 300, -1, -300, 2147483647, -2147483648])
+def test_varint_roundtrip(value):
+    buf = BufferedPacket()
+    buf.write_varint(value)
+    buf.flip()
+    assert buf.read_varint() == value


### PR DESCRIPTION
## Summary
- ensure `write_varint`/`read_varint` correctly handle signed values
- do the same for `write_varlong`/`read_varlong`
- add pytest covering varint round trips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c803c63c832091eb482d9a4393e8