### PR TITLE
Refactor ByteBuffer implementation

### DIFF
--- a/networking/socket_io.py
+++ b/networking/socket_io.py
@@ -59,7 +59,7 @@ class ConnectionInputStream:
             logger.debug(f'Received {data}')
             with self._buffer_lock:
                 new_buffer = ByteBuffer(byte_order='big')
-                old_buffer_data = self._buffer.buffer.copy()[self._buffer.position:]
+                old_buffer_data = self._buffer.buffer.getvalue()[self._buffer.position:]
                 new_buffer.wrap(old_buffer_data, auto_flip=False)
                 new_buffer.write(data)
                 new_buffer.flip()


### PR DESCRIPTION
## Summary
- refactor ByteBuffer to use `io.BytesIO`
- adjust socket reading logic for new buffer

## Testing
- `python3 -m py_compile networking/data_type.py networking/socket_io.py networking/packet/__init__.py`
- `python3 -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6857425e65c883208ef11be961a7588e