### PR TITLE
Add TagFloat NBT class

### DIFF
--- a/core/__main__.py
+++ b/core/__main__.py
@@ -21,4 +21,5 @@ if __name__ == "__main__":
 
     tag = nbt.TagCompound(name="This is the root tag you know")
     tag.value.append(nbt.TagByte(name="hey its just a test", value=42))
+    tag.value.append(nbt.TagFloat(name="float test", value=3.14))
     print(tag)

--- a/minecraft_py/nbt.py
+++ b/minecraft_py/nbt.py
@@ -2,6 +2,7 @@
 from abc import ABC, abstractmethod
 from io import BytesIO
 from gzip import GzipFile
+import struct
 
 from networking.data_type import ByteBuffer
 
@@ -160,6 +161,35 @@ class TagByte(NBTBase):
         tag = super().from_payload(payload)
         value = payload.read(1)[0]
         tag.value = value - 256 if value > 127 else value
+        return tag
+
+@NBTBase.register_tag(0x05)
+class TagFloat(NBTBase):
+    """
+    Represents a float NBT tag.
+    """
+
+    def __init__(self, name: str=None, value: float=None):
+        super().__init__(name, value)
+
+    def _check_value(self, value: float):
+        if value is not None and not isinstance(value, (int, float)):
+            raise ValueError("Float value must be a numeric type")
+
+    def to_snbt(self) -> str:
+        if self.value is None:
+            return None
+        return f'{self.name}:{float(self.value)}f' if self.name else f'{float(self.value)}f'
+
+    def to_payload(self) -> ByteBuffer:
+        payload = super().to_payload()
+        payload.write(struct.pack(f'{payload._byte_order_notation()}f', float(self.value)), auto_flip=True)
+        return payload
+
+    @classmethod
+    def from_payload(cls, payload: ByteBuffer) -> 'TagFloat':
+        tag = super().from_payload(payload)
+        tag.value = struct.unpack(f'{payload._byte_order_notation()}f', payload.read(4))[0]
         return tag
 
 @NBTBase.register_tag(0x0A)


### PR DESCRIPTION
## Summary
- support float NBT data by adding `TagFloat`
- demonstrate `TagFloat` usage in the main example

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857666c1a1c83209bc60a6f6c47d093